### PR TITLE
Fixed domains not capturing errors occurring within promises

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -28,6 +28,8 @@ var next = 'function' == typeof setImmediate
  */
 
 function Promise (back) {
+  EventEmitter.call(this);
+
   this.emitted = {};
   this.ended = false;
   if ('function' == typeof back)


### PR DESCRIPTION
When using mongoose within a domain, any error that occurs in a callback query fails.
