### PR TITLE
Add partial support for ES6-style promises with #catch method

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -219,6 +219,34 @@ Promise.prototype.then = function (onFulfill, onReject) {
   return newPromise;
 };
 
+/**
+ * Creates a new promise and returns it. If `onReject` are passed, 
+ * it is added as an ERROR callback to this promise after the next tick.
+ *
+ * Extends the [promises/A+](https://github.com/promises-aplus/promises-spec) specification,
+ * by providing a sugared version of #then as outlined in the ES6 Promises proposal
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
+ *
+ * ####Example:
+ *
+ *     var p = new Promise;
+ *     p.then(function (arg) {
+ *       return arg + 1;
+ *     }).then(function (arg) {
+ *       throw new Error(arg + ' is an error!');
+ *     }).catch(function (err) {
+ *       assert.ok(err instanceof Error);
+ *       assert.equal('2 is an error', err.message);
+ *     });
+ *
+ * @see Promise.prototype.catch() https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
+ * @param {Function} [onReject]
+ * @return {Promise} newPromise
+ */
+Promise.prototype.catch = function (onReject) {
+  return this.then(null, onReject);
+};
+
 
 function handler(promise, fn) {
   function newTickHandler() {

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -338,6 +338,19 @@ describe('promise', function () {
     });
   });
 
+  describe('catch', function () {
+    describe('onReject', function () {
+      it("should be called when a promise is rejected", function (done) {
+        var p = new Promise;
+        var rejection = 'foo';
+        p.reject(rejection);
+        p.catch(function(reason) {
+          assert.equal(rejection, reason);
+          done();
+        });
+      });
+    });
+  });
 
   describe('end', function () {
     it("should return the promise", function (done) {


### PR DESCRIPTION
This would fix #15, and I would really appreciate the merge :D

Let me know if you'd like more tests, I was sort of skimpy on them because this simply wraps `#then`.
